### PR TITLE
Redo implementation

### DIFF
--- a/app_ai.js
+++ b/app_ai.js
@@ -196,9 +196,15 @@ document.addEventListener('DOMContentLoaded', () => {
    * coloured red and potential checking moves are coloured orange.
    */
   function updateThreatOverlay() {
+    // Ensure the SVG overlay exists before drawing arrows.  If it
+    // hasn't been created yet, call initThreatOverlay() now.  This
+    // allows updateThreatOverlay() to be called safely even if the
+    // threat overlay wasn't initialised earlier (for example, after
+    // reloading the page or when new features are added).
+    initThreatOverlay();
     const overlay = document.getElementById('threat-overlay');
     if (!overlay) return;
-    // Clear existing arrows
+    // Clear existing arrows but preserve marker definitions in the <defs> element.
     overlay.innerHTML = overlay.innerHTML.split('</defs>')[0] + '</defs>';
     if (!showThreats) return;
     // Determine which colour is the opponent

--- a/app_ai.js
+++ b/app_ai.js
@@ -105,9 +105,16 @@ document.addEventListener('DOMContentLoaded', () => {
   function redoMove() {
     if (aiThinking || redoStack.length === 0) return;
     const move = redoStack.pop();
-    // Apply the move exactly as it was undone.  Chess.js allows passing
-    // the move object returned by undo() directly to move().
-    game.move(move);
+    // Apply the move exactly as it was undone.  Construct a minimal
+    // move object containing only the fields accepted by chess.js: from,
+    // to and promotion.  The move returned by undo() contains
+    // additional metadata but can still be used to populate these
+    // fields.  When promotion is undefined, omit the field.
+    const redoObj = { from: move.from, to: move.to };
+    if (move.promotion) {
+      redoObj.promotion = move.promotion;
+    }
+    game.move(redoObj);
     selectedSquare = null;
     possibleMoves = [];
     renderBoard();


### PR DESCRIPTION
This PR implements the redo move feature.

Key points:
- A redo button now appears alongside the other controls.
- Moves undone via the undo button are pushed onto a redo stack.
- Clicking the redo button pops the last undone move off the stack and reapplies it using the chess.js API.
- The redo stack is cleared whenever a new move is played (either by the player or the AI) to prevent replaying invalid history.
- The 
- Ensures the threat overlay element is created when updating threat arrows so the lines display properly.threat overlay and move list are refreshed after redoing a move.

This change should work with the existing undo, reset, flip, and threat toggle features.
